### PR TITLE
Return component data as alists

### DIFF
--- a/config/common.lisp
+++ b/config/common.lisp
@@ -105,7 +105,7 @@
           err))))
 
 
-(defun component-data-maker (method data-alist defaults-alist keys)
+(defun component-data-maker (data-alist defaults-alist keys)
   (let ((data-alist (eval data-alist))
         (defaults-alist (eval defaults-alist))
         (args-alist))
@@ -116,7 +116,7 @@
         (if-let ((val (alist-get key defaults-alist)))
             (setq args-alist (cons (cons key `(quote ,val)) args-alist)))))
 
-    (list 'lambda '(_) `(,method ,args-alist))))
+    (list 'lambda '(_) `(quote ,args-alist))))
 
 
 (defun quote-each-value (alist)

--- a/config/components.lisp
+++ b/config/components.lisp
@@ -137,8 +137,7 @@
 ;;;;;;;;;;;;;;;
 
 (defmacro battery-data-maker (data-alist defaults-alist)
-  (component-data-maker 'battery-data
-                        data-alist
+  (component-data-maker data-alist
                         defaults-alist
                         '(id soc soc-upper soc-lower
                           capacity power voltage type
@@ -181,8 +180,7 @@
 ;;;;;;;;;;;;;;;
 
 (defmacro inverter-data-maker (data-alist defaults-alist)
-  (component-data-maker 'inverter-data
-                        data-alist
+  (component-data-maker data-alist
                         defaults-alist
                         '(id power current voltage component-state
                           inclusion-lower inclusion-upper)))
@@ -223,8 +221,7 @@
 ;;;;;;;;;;;;
 
 (defmacro meter-data-maker (data-alist defaults-alist)
-  (component-data-maker 'meter-data
-                        data-alist
+  (component-data-maker data-alist
                         defaults-alist
                         '(id power current voltage)))
 


### PR DESCRIPTION
Previously the lisp code was return `ComponentData` objects as `Rc<dyn Any>`.  This is no longer the case and the alists returned by the lisp code are converted to `ComponentData` on the rust side.

This allows writing tests in lisp for the component data methods, because they just return alists and those can be verified by lisp.