### PR TITLE
Make config path cli parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +261,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -617,6 +713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +809,7 @@ name = "microsim"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clap",
  "futures",
  "log",
  "notify",
@@ -824,6 +927,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
@@ -1134,6 +1243,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4.22"
 simplelog = "0.12.2"
 rand = "0.8.5"
 chrono = "0.4.42"
+clap = { version = "4.5", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/src/lisp.rs
+++ b/src/lisp.rs
@@ -96,6 +96,7 @@ intern! {
 #[derive(Clone)]
 pub struct Config {
     filename: String,
+    config_dir: String,
 
     pub(crate) ctx: Rc<RefCell<tulisp::TulispContext>>,
 
@@ -260,14 +261,40 @@ impl Config {
         let mut ctx = tulisp::TulispContext::new();
         add_functions(&mut ctx);
 
-        let _ = ctx.eval_file(filename).map_err(|e| {
+        // Get the directory of the config file
+        let config_path = Path::new(filename);
+        let config_dir = config_path
+            .parent()
+            .and_then(|p| p.to_str())
+            .unwrap_or(".")
+            .to_string();
+
+        // Change to config directory before loading to ensure relative paths work
+        let original_dir = std::env::current_dir().unwrap();
+        if let Some(parent) = config_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                let _ = std::env::set_current_dir(parent);
+            }
+        }
+
+        let config_filename = config_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or(filename);
+
+        let _ = ctx.eval_file(config_filename).map_err(|e| {
             log::error!("Tulisp error:\n{}", e.format(&ctx));
             e
         });
+
+        // Restore original directory
+        let _ = std::env::set_current_dir(original_dir);
+
         let now = std::time::Instant::now();
         let symbols = Symbols::new(&mut ctx);
         Self {
             filename: filename.to_string(),
+            config_dir,
             ctx: Rc::new(RefCell::new(ctx)),
             stream_methods: Rc::new(RefCell::new(HashMap::new())),
             last_formula_update_time: Rc::new(RefCell::new(now)),
@@ -279,16 +306,35 @@ impl Config {
     pub fn reload(&self) {
         let start = std::time::Instant::now();
         let mut ctx = self.ctx.borrow_mut();
+
+        // Change to config directory before reloading
+        let original_dir = std::env::current_dir().unwrap();
+        if !self.config_dir.is_empty() && self.config_dir != "." {
+            let _ = std::env::set_current_dir(&self.config_dir);
+        }
+
+        let config_path = Path::new(&self.filename);
+        let config_filename = config_path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or(&self.filename);
+
         if ctx
-            .eval_file(&self.filename)
+            .eval_file(config_filename)
             .map_err(|e| {
                 log::error!("Tulisp error:\n{}", e.format(&ctx));
                 e
             })
             .is_err()
         {
+            // Restore original directory even on error
+            let _ = std::env::set_current_dir(original_dir);
             return;
         }
+
+        // Restore original directory
+        let _ = std::env::set_current_dir(original_dir);
+
         let duration = start.elapsed();
         log::info!(
             "Reloaded config file in {}ms",

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,26 @@ mod proto;
 mod server;
 mod timeout_tracker;
 
+use clap::Parser;
 use proto::microgrid::v1alpha18::microgrid_server;
 use tonic::transport::Server;
+
+#[derive(Parser)]
+#[command(name = "microsim")]
+#[command(about = "Microgrid simulator", long_about = None)]
+struct Args {
+    /// Path to the configuration file
+    #[arg(short, long, default_value = "config.lisp")]
+    config: String,
+}
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     simplelog::SimpleLogger::init(simplelog::LevelFilter::Debug, simplelog::Config::default())
         .unwrap();
 
-    let config = lisp::Config::new("config.lisp");
+    let args = Args::parse();
+    let config = lisp::Config::new(&args.config);
     tokio::spawn(config.clone().start());
     let socket_addr = config.socket_addr();
     log::info!("Server listening on {}", socket_addr);


### PR DESCRIPTION
This pull request introduces support for command-line configuration file selection using `clap`, and improves how configuration files are loaded and reloaded by ensuring relative paths are resolved correctly. The changes also enhance robustness when handling file paths and working directories.

**Command-line interface improvements:**

* Added the `clap` dependency with derive support in `Cargo.toml` and introduced a new `Args` struct in `main.rs` to allow specifying the configuration file path via a `--config` command-line argument. The default remains `config.lisp`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R19) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR6-R25)

**Configuration file loading and path handling:**

* Modified the `Config` struct in `lisp.rs` to store the configuration directory, and updated the initialization logic to change the working directory to the config file's directory before loading, ensuring relative paths in the config are resolved correctly. The original directory is restored after loading. [[1]](diffhunk://#diff-774b669ed71d59587f3f29be88cac898cd2beffbac0f514c661df6e35661a599R99) [[2]](diffhunk://#diff-774b669ed71d59587f3f29be88cac898cd2beffbac0f514c661df6e35661a599L263-R297)
* Updated the `reload` method in `Config` to switch to the config directory before reloading and restore the original directory afterward, improving reliability when reloading configuration files.